### PR TITLE
Add comprehensive HA/DR for single-instance deployment: watchdog, warm standby, DR drills

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,7 +104,7 @@ The `README.md` (single-server guide) follows a strict 14-step deployment sequen
 10. **Verification** — Security audit, health checks, connectivity tests
 11. **Maintenance** — Backup scripts, token rotation, cron
 12. **Troubleshooting** — Symptom/diagnostic/fix table
-13. **Disaster Recovery** — Recovery objectives, restore procedure
+13. **High Availability and Disaster Recovery** — HA foundations, watchdog monitoring, unattended updates, external uptime checks, backup verification, recovery procedure, warm standby, DR drills
 14. **Scaling** — Vertical scaling, LiteLLM proxy, channel partitioning, Swarm migration
 
 **Deployment order matters**: The Compose file defines `depends_on` with health conditions, so `docker compose up -d` handles service ordering automatically. Hardening (Step 5) must be applied before exposing the gateway to traffic (Step 9).


### PR DESCRIPTION
Expand Step 13 from basic disaster recovery (2 subsections) to full
HA/DR coverage (11 subsections): HA foundations explainer, health
monitoring watchdog script with alerting, unattended security updates,
external uptime monitoring options, recovery objectives with MTTR,
backup verification script, post-recovery checklist, warm standby
procedure, and quarterly DR drill schedule.

https://claude.ai/code/session_016kwbV9Lvko2P84zzVHu2FV