### PR TITLE
Fix community.general.yaml removal in v12: use built-in result_format=yaml

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -4,7 +4,8 @@ roles_path = roles
 remote_tmp = /tmp/.ansible-${USER}
 forks = 5
 pipelining = true
-stdout_callback = yaml
+stdout_callback = default
+result_format = yaml
 callbacks_enabled = profile_tasks
 
 # Retry failed hosts once (useful for transient SSH issues on fresh VPS)


### PR DESCRIPTION
The community.general.yaml callback plugin was removed in collection
v12.0.0. Switch stdout_callback to the built-in default plugin and set
result_format=yaml to get identical YAML output (available since
ansible-core 2.13).

https://claude.ai/code/session_01W92BBHtZzik7My5Ct4ndTY