### PR TITLE
Fix Ansible timeout during privilege escalation on loaded VPS

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -3,6 +3,7 @@ inventory = inventory/hosts.yml
 roles_path = roles
 remote_tmp = /tmp/.ansible-${USER}
 forks = 5
+timeout = 30
 pipelining = true
 stdout_callback = default
 result_format = yaml
@@ -16,6 +17,7 @@ retry_files_save_path = .retry
 become = true
 become_method = sudo
 become_user = root
+timeout = 30
 
 [ssh_connection]
 ssh_args = -o ControlMaster=auto -o ControlPersist=60s -o StrictHostKeyChecking=accept-new -o IdentitiesOnly=yes


### PR DESCRIPTION
Bump both connection timeout and become timeout from defaults (~10-12s)
to 30s. The privilege escalation prompt was timing out mid-loop during
directory creation, right after Docker install and fail2ban restart
loaded the server.

https://claude.ai/code/session_01Kvu7eevgsvHCCT9XBxKQ6u