### PR TITLE
Fix 2 docker pull failures: migrate images to GHCR, correct socket-proxy tag

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This repository is the **OpenClaw Hardened Single-Server Deployment** guide — 
 **This is a documentation-only repository.** There is no application source code, no build system, and no automated tests. All content lives in Markdown files and a Claude Code settings file.
 
 - **Target**: 1 Ubuntu 24.04 KVM VPS (16 vCPU, 64 GB RAM, 8 GB swap, 4 TB NVMe)
-- **OpenClaw Version**: `openclaw/openclaw:2026.2.23` (pinned)
+- **OpenClaw Version**: `ghcr.io/openclaw/openclaw:2026.2.23` (pinned)
 - **Threat Model**: Prompt injection → arbitrary tool execution → host/container escape
 
 ## Repository Structure
@@ -77,8 +77,8 @@ Three bridge networks enforce least-privilege communication. `openclaw-net` is *
 
 | Service | Image | Purpose | Network |
 |---------|-------|---------|---------|
-| `docker-proxy` | `tecnativa/docker-socket-proxy:0.6.0` | Sandboxed Docker API access (EXEC only) | `openclaw-net` |
-| `openclaw` | `openclaw/openclaw:2026.2.23` | Main gateway — agent runtime, tool execution | `openclaw-net` + `proxy-net` |
+| `docker-proxy` | `ghcr.io/tecnativa/docker-socket-proxy:v0.4.2` | Sandboxed Docker API access (EXEC only) | `openclaw-net` |
+| `openclaw` | `ghcr.io/openclaw/openclaw:2026.2.23` | Main gateway — agent runtime, tool execution | `openclaw-net` + `proxy-net` |
 | `litellm` | `ghcr.io/berriai/litellm:main-v1.81.3-stable` | LLM API proxy — routing, cost controls, caching | `openclaw-net` |
 | `openclaw-egress` | `ubuntu/squid:6.6-24.04_edge` | Egress whitelist proxy for LLM API calls | `openclaw-net` + `egress-net` |
 | `redis` | `redis/redis-stack-server:7.4.0-v3` | Semantic cache for LiteLLM (RediSearch module) | `openclaw-net` |

--- a/README.md
+++ b/README.md
@@ -588,7 +588,7 @@ EOF
 cat > /opt/openclaw/docker-compose.yml << 'COMPOSE_EOF'
 services:
   docker-proxy:
-    image: tecnativa/docker-socket-proxy:0.6.0
+    image: ghcr.io/tecnativa/docker-socket-proxy:v0.4.2
     container_name: openclaw-docker-proxy
     environment:
       CONTAINERS: "1"
@@ -636,7 +636,7 @@ services:
     restart: unless-stopped
 
   openclaw:
-    image: openclaw/openclaw:2026.2.23
+    image: ghcr.io/openclaw/openclaw:2026.2.23
     container_name: openclaw
     environment:
       DOCKER_HOST: tcp://openclaw-docker-proxy:2375
@@ -2199,8 +2199,8 @@ A pre-staged standby is a pre-provisioned server that mirrors the production con
 
 ```bash
 # On the standby server
-docker pull openclaw/openclaw:2026.2.23
-docker pull tecnativa/docker-socket-proxy:0.6.0
+docker pull ghcr.io/openclaw/openclaw:2026.2.23
+docker pull ghcr.io/tecnativa/docker-socket-proxy:v0.4.2
 docker pull ubuntu/squid:6.6-24.04_edge
 docker pull ghcr.io/berriai/litellm:main-v1.81.3-stable
 docker pull redis/redis-stack-server:7.4.0-v3
@@ -2512,7 +2512,7 @@ The scaling pattern is **bot partitioning**: create multiple Telegram bots (via 
 cat > /opt/openclaw/compose.secondary.yml << 'EOF'
 services:
   openclaw-secondary:
-    image: openclaw/openclaw:2026.2.23
+    image: ghcr.io/openclaw/openclaw:2026.2.23
     container_name: openclaw-secondary
     environment:
       DOCKER_HOST: tcp://openclaw-docker-proxy:2375

--- a/RESEARCH_CLAW.md
+++ b/RESEARCH_CLAW.md
@@ -96,8 +96,8 @@ User Message → Channel (Telegram/Discord) → Gateway → LLM (via LiteLLM) �
 
 | Container | Image | CPU | RAM | Role | Talks To |
 |-----------|-------|-----|-----|------|----------|
-| `openclaw` | `openclaw/openclaw:2026.2.23` | 8.0 | 16G | Agent runtime, Gateway, Web UI | docker-proxy, litellm, egress |
-| `openclaw-docker-proxy` | `tecnativa/docker-socket-proxy:0.6.0` | 0.5 | 256M | Sandboxed Docker API | host docker.sock |
+| `openclaw` | `ghcr.io/openclaw/openclaw:2026.2.23` | 8.0 | 16G | Agent runtime, Gateway, Web UI | docker-proxy, litellm, egress |
+| `openclaw-docker-proxy` | `ghcr.io/tecnativa/docker-socket-proxy:v0.4.2` | 0.5 | 256M | Sandboxed Docker API | host docker.sock |
 | `openclaw-egress` | `ubuntu/squid:6.6-24.04_edge` | 0.5 | 256M | Egress whitelist proxy | internet (whitelisted) |
 | `openclaw-litellm` | `ghcr.io/berriai/litellm:main-v1.81.3-stable` | 2.0 | 2G | LLM proxy + spend caps | LLM providers (via egress) |
 | `openclaw-redis` | `redis/redis-stack-server:7.4.0-v3` | 0.5 | 512M | Semantic cache (vector search) | litellm |

--- a/group_vars/all/vars.yml
+++ b/group_vars/all/vars.yml
@@ -11,7 +11,7 @@ local_ssh_key_path: "{{ lookup('env', 'HOME') }}/.ssh/id_ed25519"
 
 # ── Image Versions (pinned) ───────────────────────────────────────────
 openclaw_version: "2026.2.23"
-docker_proxy_version: "0.6.0"
+docker_proxy_version: "v0.4.2"
 squid_version: "6.6-24.04_edge"
 litellm_version: "main-v1.81.3-stable"
 redis_version: "7.4.0-v3"

--- a/roles/openclaw-config/templates/docker-compose.yml.j2
+++ b/roles/openclaw-config/templates/docker-compose.yml.j2
@@ -1,6 +1,6 @@
 services:
   docker-proxy:
-    image: tecnativa/docker-socket-proxy:{{ docker_proxy_version }}
+    image: ghcr.io/tecnativa/docker-socket-proxy:{{ docker_proxy_version }}
     container_name: openclaw-docker-proxy
     environment:
       CONTAINERS: "1"
@@ -48,7 +48,7 @@ services:
     restart: unless-stopped
 
   openclaw:
-    image: openclaw/openclaw:{{ openclaw_version }}
+    image: ghcr.io/openclaw/openclaw:{{ openclaw_version }}
     container_name: openclaw
     environment:
       DOCKER_HOST: tcp://openclaw-docker-proxy:2375

--- a/roles/openclaw-deploy/tasks/main.yml
+++ b/roles/openclaw-deploy/tasks/main.yml
@@ -6,8 +6,8 @@
     name: "{{ item }}"
     source: pull
   loop:
-    - "openclaw/openclaw:{{ openclaw_version }}"
-    - "tecnativa/docker-socket-proxy:{{ docker_proxy_version }}"
+    - "ghcr.io/openclaw/openclaw:{{ openclaw_version }}"
+    - "ghcr.io/tecnativa/docker-socket-proxy:{{ docker_proxy_version }}"
     - "ubuntu/squid:{{ squid_version }}"
     - "ghcr.io/berriai/litellm:{{ litellm_version }}"
     - "redis/redis-stack-server:{{ redis_version }}"


### PR DESCRIPTION
- openclaw/openclaw → ghcr.io/openclaw/openclaw (image not on Docker Hub)
- tecnativa/docker-socket-proxy:0.6.0 → ghcr.io/tecnativa/docker-socket-proxy:v0.4.2
  (tag 0.6.0 never existed; project migrated to GHCR, latest stable is v0.4.2)

https://claude.ai/code/session_01GexnosLYkopYRxXnsfsb5F