### PR TITLE
Fix 3 Docker startup failures: missing tmpfs mounts, missing depends_on

### DIFF
--- a/README.md
+++ b/README.md
@@ -620,6 +620,7 @@ services:
     read_only: true
     tmpfs:
       - /tmp:size=16M
+      - /run:size=8M
     security_opt:
       - no-new-privileges:true
     healthcheck:
@@ -698,6 +699,8 @@ services:
     depends_on:
       redis:
         condition: service_healthy
+      openclaw-egress:
+        condition: service_healthy
     healthcheck:
       test: ["CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:4000/health/liveliness || exit 1"]
       interval: 30s
@@ -724,6 +727,7 @@ services:
       - /var/spool/squid:size=64M
       - /var/log/squid:size=32M
       - /var/run:size=8M
+      - /tmp:size=16M
     security_opt:
       - no-new-privileges:true
     healthcheck:

--- a/roles/openclaw-config/templates/docker-compose.yml.j2
+++ b/roles/openclaw-config/templates/docker-compose.yml.j2
@@ -32,6 +32,7 @@ services:
     read_only: true
     tmpfs:
       - /tmp:size=16M
+      - /run:size=8M
     security_opt:
       - no-new-privileges:true
     healthcheck:
@@ -108,6 +109,8 @@ services:
     depends_on:
       redis:
         condition: service_healthy
+      openclaw-egress:
+        condition: service_healthy
     healthcheck:
       test: ["CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:4000/health/liveliness || exit 1"]
       interval: 30s
@@ -134,6 +137,7 @@ services:
       - /var/spool/squid:size=64M
       - /var/log/squid:size=32M
       - /var/run:size=8M
+      - /tmp:size=16M
     security_opt:
       - no-new-privileges:true
     healthcheck:


### PR DESCRIPTION
- docker-proxy: add /run tmpfs — HAProxy needs writable /run for PID file
  and admin socket (caused immediate exit 1 with read_only: true)
- openclaw-egress: add /tmp tmpfs — Squid entrypoint needs writable /tmp
  for initialization (caused immediate exit 1 with read_only: true)
- litellm: add depends_on openclaw-egress — LiteLLM routes all outbound
  HTTPS through the egress proxy but started before it was healthy

https://claude.ai/code/session_01ByvT7mb4F57oGFcaQDAGAx