### PR TITLE
Improve Squid healthcheck and update tmpfs mount path

### DIFF
--- a/README.md
+++ b/README.md
@@ -726,12 +726,12 @@ services:
     tmpfs:
       - /var/spool/squid:size=64M
       - /var/log/squid:size=32M
-      - /var/run:size=8M
+      - /run:size=8M
       - /tmp:size=16M
     security_opt:
       - no-new-privileges:true
     healthcheck:
-      test: ["CMD-SHELL", "squidclient -h localhost mgr:info 2>&1 | grep -q 'Squid Object Cache' || exit 1"]
+      test: ["CMD-SHELL", "squid -k check 2>/dev/null || exit 1"]
       interval: 30s
       timeout: 5s
       retries: 3

--- a/roles/openclaw-config/templates/docker-compose.yml.j2
+++ b/roles/openclaw-config/templates/docker-compose.yml.j2
@@ -136,12 +136,12 @@ services:
     tmpfs:
       - /var/spool/squid:size=64M
       - /var/log/squid:size=32M
-      - /var/run:size=8M
+      - /run:size=8M
       - /tmp:size=16M
     security_opt:
       - no-new-privileges:true
     healthcheck:
-      test: ["CMD-SHELL", "squidclient -h localhost mgr:info 2>&1 | grep -q 'Squid Object Cache' || exit 1"]
+      test: ["CMD-SHELL", "squid -k check 2>/dev/null || exit 1"]
       interval: 30s
       timeout: 5s
       retries: 3


### PR DESCRIPTION
## Summary
Updated Squid container configuration to use a more reliable healthcheck method and modernized the tmpfs mount path for runtime files.

## Key Changes
- **Healthcheck improvement**: Replaced `squidclient`-based health check with `squid -k check` command
  - The new method is more direct and doesn't require the management client utility
  - Simplifies error handling by redirecting stderr to /dev/null
  
- **Tmpfs mount path update**: Changed `/var/run` to `/run`
  - `/run` is the modern standard location for runtime files in Linux systems
  - `/var/run` is typically a symlink to `/run` in contemporary distributions

## Files Modified
- `README.md` - Updated documentation example
- `roles/openclaw-config/templates/docker-compose.yml.j2` - Updated Ansible template

Both files contain identical Squid service configuration and have been updated consistently.

https://claude.ai/code/session_01UGLqiBTFqdgnKk4hck3cR6