### PR TITLE
Fix Smokescreen build failure: pin to valid release tag v0.0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,6 +465,7 @@ FROM golang:1.22-alpine AS builder
 RUN apk add --no-cache git
 WORKDIR /src
 RUN git clone https://github.com/stripe/smokescreen.git . && \
+    git checkout v0.0.4 && \
     CGO_ENABLED=0 go build -ldflags="-s -w" -o /smokescreen .
 
 FROM alpine:3.20

--- a/group_vars/all/vars.yml
+++ b/group_vars/all/vars.yml
@@ -14,7 +14,7 @@ openclaw_version: "2026.2.23"
 docker_proxy_version: "v0.4.2"
 # Smokescreen is built from source (no pre-built image).
 # Pin to a specific commit for reproducible builds.
-smokescreen_commit: "5dce0f3"
+smokescreen_commit: "v0.0.4"
 smokescreen_go_version: "1.22"
 smokescreen_alpine_version: "3.20"
 litellm_version: "main-v1.81.3-stable"


### PR DESCRIPTION
The commit hash 5dce0f3 does not exist in stripe/smokescreen, causing
`git checkout` to fail during the Docker multi-stage build. Replace with
the latest release tag v0.0.4 and add version pinning to the inline
README Dockerfile for reproducible builds.

https://claude.ai/code/session_01DFzN6vpueTTRCF8kLQTULA