### PR TITLE
Fix Smokescreen ACL parse error: services must be a YAML map, not list

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,7 +487,7 @@ cat > /opt/openclaw/config/smokescreen-acl.yaml << 'EOF'
 # publicly routable (blocks RFC 1918 / link-local / loopback).
 version: v1
 
-services: []
+services: {}
 
 default:
   project: openclaw

--- a/roles/openclaw-config/templates/smokescreen-acl.yaml.j2
+++ b/roles/openclaw-config/templates/smokescreen-acl.yaml.j2
@@ -10,7 +10,7 @@
 
 version: v1
 
-services: []
+services: {}
 
 default:
   project: openclaw


### PR DESCRIPTION
Smokescreen's Go ACL loader expects `services` to be map[string]*Rule.
The empty array `[]` fails YAML unmarshaling, crashing the proxy on
startup and blocking all dependent services (litellm, openclaw).

https://claude.ai/code/session_0125UP7ULkWqYrmFgHTEu1U4