### PR TITLE
Fix egress container crash: remove unsupported Smokescreen CLI flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -724,8 +724,6 @@ services:
     command:
       - "--egress-acl-file=/etc/smokescreen/acl.yaml"
       - "--listen-ip=0.0.0.0"
-      - "--expose-prometheus-metrics"
-      - "--prometheus-listen-ip=0.0.0.0"
       - "--deny-range=10.0.0.0/8"
       - "--deny-range=172.16.0.0/12"
       - "--deny-range=192.168.0.0/16"

--- a/roles/openclaw-config/templates/docker-compose.yml.j2
+++ b/roles/openclaw-config/templates/docker-compose.yml.j2
@@ -132,8 +132,6 @@ services:
     command:
       - "--egress-acl-file=/etc/smokescreen/acl.yaml"
       - "--listen-ip=0.0.0.0"
-      - "--expose-prometheus-metrics"
-      - "--prometheus-listen-ip=0.0.0.0"
       - "--deny-range=10.0.0.0/8"
       - "--deny-range=172.16.0.0/12"
       - "--deny-range=192.168.0.0/16"


### PR DESCRIPTION
Smokescreen v0.0.4 does not support --expose-prometheus-metrics or
--prometheus-listen-ip. These unknown flags cause exit code 1 on
startup, putting the container in a restart loop and cascading failure
to litellm and openclaw via depends_on health conditions.

https://claude.ai/code/session_015zgK5BZPvPHXuiybrjW9Y1