### PR TITLE
Fix 2 Ansible issues: quote memory values, add subnet discovery to harden role

### DIFF
--- a/roles/openclaw-config/templates/docker-compose.yml.j2
+++ b/roles/openclaw-config/templates/docker-compose.yml.j2
@@ -47,7 +47,7 @@ services:
       resources:
         limits:
           cpus: "{{ docker_proxy_cpus }}"
-          memory: {{ docker_proxy_memory }}
+          memory: "{{ docker_proxy_memory }}"
     restart: unless-stopped
 
   openclaw:
@@ -87,9 +87,9 @@ services:
       resources:
         limits:
           cpus: "{{ openclaw_cpus }}"
-          memory: {{ openclaw_memory }}
+          memory: "{{ openclaw_memory }}"
         reservations:
-          memory: {{ openclaw_memory_reservation }}
+          memory: "{{ openclaw_memory_reservation }}"
     restart: unless-stopped
 
   litellm:
@@ -130,7 +130,7 @@ services:
       resources:
         limits:
           cpus: "{{ litellm_cpus }}"
-          memory: {{ litellm_memory }}
+          memory: "{{ litellm_memory }}"
     restart: unless-stopped
 
   openclaw-egress:
@@ -168,7 +168,7 @@ services:
       resources:
         limits:
           cpus: "{{ smokescreen_cpus }}"
-          memory: {{ smokescreen_memory }}
+          memory: "{{ smokescreen_memory }}"
     restart: unless-stopped
 
   redis:
@@ -203,7 +203,7 @@ services:
       resources:
         limits:
           cpus: "{{ redis_cpus }}"
-          memory: {{ redis_memory }}
+          memory: "{{ redis_memory }}"
     restart: unless-stopped
 
 networks:

--- a/roles/openclaw-harden/tasks/main.yml
+++ b/roles/openclaw-harden/tasks/main.yml
@@ -2,6 +2,24 @@
 # Step 5: Gateway and sandbox hardening
 # All config applied via docker exec — idempotent (config set is a no-op if value matches)
 
+# Discover proxy-net subnet if not already set (e.g., when running --tags harden standalone).
+# The deploy role sets this as a fact, but facts don't persist across separate playbook runs.
+- name: Discover proxy-net subnet (if not already set)
+  when: proxy_net_subnet is not defined
+  block:
+    - name: Get proxy-net subnet from Docker
+      ansible.builtin.command: >
+        docker network inspect openclaw_proxy-net
+        --format '{{ '{{' }}range .IPAM.Config{{ '}}' }}{{ '{{' }}.Subnet{{ '}}' }}{{ '{{' }}end{{ '}}' }}'
+      register: _proxy_subnet_discovery
+      changed_when: false
+      failed_when: false
+
+    - name: Store discovered proxy-net subnet
+      ansible.builtin.set_fact:
+        proxy_net_subnet: "{{ _proxy_subnet_discovery.stdout }}"
+      when: _proxy_subnet_discovery.rc == 0 and _proxy_subnet_discovery.stdout | length > 0
+
 - name: Back up OpenClaw config before hardening
   ansible.builtin.command: >
     docker exec openclaw


### PR DESCRIPTION
## What

<!-- One sentence: what does this PR do? -->

## Why

<!-- What problem does it solve? -->

## Testing

- [ ] `make lint` passes (`yamllint .` + `ansible-lint` + syntax check)
- [ ] `make test` passes (`molecule test`)
- [ ] `ansible-playbook playbook.yml --check --diff` reviewed for unintended changes

## Deployment step affected

<!-- Which of the 14 steps does this change? (Step 1–14, Automated Deployment, or N/A) -->

## Security checklist

- [ ] No secrets or real IPs hardcoded
- [ ] No new sensitive API endpoints exposed
- [ ] Hardening not weakened