### PR TITLE
Pin exact versions in requirements.txt to fix missing version lockfile issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-ansible
-ansible-lint
-molecule
-molecule-plugins[docker]
-yamllint
+ansible==13.4.0
+ansible-lint==26.2.0
+molecule==26.3.0
+molecule-plugins[docker]==25.8.12
+yamllint==1.38.0


### PR DESCRIPTION
Bare package names (ansible, molecule, etc.) cause non-reproducible installs
and prevent vulnerability scanners from identifying which versions are in use.
Pinned to latest stable PyPI releases as of 2026-03-10.

https://claude.ai/code/session_01W5Jief3kCcZumNm5ij85V9