### PR TITLE
Add Docker Build Cloud job to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,8 +128,8 @@ jobs:
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ vars.DOCKER_USER }}
-          password: ${{ secrets.DOCKER_PAT }}
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
@@ -138,7 +138,7 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
-          tags: "${{ vars.DOCKER_USER }}/docker-build-cloud-demo:latest"
+          tags: "${{ vars.DOCKERHUB_USERNAME }}/docker-build-cloud-demo:latest"
           # For pull requests, export results to the build cache.
           # Otherwise, push to a registry.
           outputs: ${{ github.event_name == 'pull_request' && 'type=cacheonly' || 'type=registry' }}


### PR DESCRIPTION
Appends a `docker` job that logs in to Docker Hub, configures Docker
Buildx with the cloud driver (droxey/clincher endpoint), and builds
or pushes the image depending on event type (cache-only on PRs, push
to registry on branch push). Job is gated on `lint` and `syntax`.

https://claude.ai/code/session_01SHkJj9Fd4vi1r8CN3zz6yg